### PR TITLE
mkdocs.yml: add links to 4 new guides

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,10 @@ pages:
 - Tutorials:
   - How RTK works: common/tutorials/rtk-introduction.md
   - How PPK works: common/tutorials/ppk-introduction.md
+  - Connecting Reach to the Internet: common/tutorials/connecting-to-the-internet.md
+  - Working with NTRIP service: common/tutorials/ntrip-workflow.md
+  - Placing GCPs in RTK mode: common/tutorials/placing-gcps.md
+  - How to download files from Reach: common/tutorials/downloading-files.md
   - Placing the base: common/tutorials/placing-the-base.md
   - ArduPilot integration: ardupilot-integration.md
   - GPS post-processing: common/tutorials/gps-post-processing.md


### PR DESCRIPTION
- ‘Connecting Reach to the Internet’ guide;
- ‘Working with NTRIP service’ guide;
- ‘Placing GCPs in RTK mode’ guide;
- ‘How to download files from Reach’ guide